### PR TITLE
add sign_raw method

### DIFF
--- a/crates/hpos_hc_connect/src/hf_agent.rs
+++ b/crates/hpos_hc_connect/src/hf_agent.rs
@@ -2,11 +2,11 @@ use super::holo_config::{self, HappsFile, APP_PORT};
 use anyhow::{anyhow, Context, Result};
 use holochain_client::{AgentPubKey, AppWebsocket};
 use holochain_conductor_api::{AppInfo, CellInfo, ProvisionedCell, ZomeCall};
-use holochain_keystore::{ AgentPubKeyExt, MetaLairClient };
+use holochain_keystore::{AgentPubKeyExt, MetaLairClient};
 use holochain_types::prelude::{
     ExternIO, FunctionName, Nonce256Bits, Signature, Timestamp, ZomeCallUnsigned, ZomeName,
 };
-use std::{time::Duration, sync::Arc};
+use std::{sync::Arc, time::Duration};
 
 pub struct HolofuelAgent {
     app_websocket: AppWebsocket,


### PR DESCRIPTION
Add sign_raw method on agent for signing raw payload with agents holfuel private key.

This method is used to create signature that holofule's `transactor/deposit` will verify.