### PR TITLE
Change the way an external_signing_key is registered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,7 +2253,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-serde",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.17",
 ]
 
 [[package]]
@@ -2432,6 +2432,7 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -2921,7 +2922,7 @@ dependencies = [
  "serde_bytes",
  "structopt",
  "tokio",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.17",
  "webpki 0.21.4",
 ]
 
@@ -3016,7 +3017,7 @@ dependencies = [
  "sqlformat 0.2.1",
  "structopt",
  "sysinfo 0.28.4",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.17",
 ]
 
 [[package]]
@@ -3260,6 +3261,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchers"
@@ -6015,11 +6025,33 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers 0.0.1",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec 1.10.0",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
+name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
- "matchers",
+ "matchers 0.1.0",
  "nu-ansi-term",
  "once_cell",
  "regex",

--- a/crates/holofuel_init/Cargo.toml
+++ b/crates/holofuel_init/Cargo.toml
@@ -10,4 +10,5 @@ hpos_hc_connect = { version="0.1.0", path = "../hpos_hc_connect" }
 tokio = { version = "1.11", features = [ "full" ] }
 serde = { version = "1.0", features = ["derive"] }
 tracing = "0.1.37"
+tracing-subscriber = "0.2"
 rmp-serde = "1.1.1"

--- a/crates/holofuel_init/src/main.rs
+++ b/crates/holofuel_init/src/main.rs
@@ -3,7 +3,7 @@ use holochain_types::prelude::{
     hash_type::Agent, holochain_serial, ExternIO, FunctionName, HoloHashB64, SerializedBytes,
     ZomeName,
 };
-use hpos_hc_connect::{holofuel_types::ReserveSetting, HolofuelAgent};
+use hpos_hc_connect::{holofuel_types::ReserveSettingFile, HolofuelAgent};
 use serde::{Deserialize, Serialize};
 use std::env;
 use tracing::{debug, info, Level};
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
     if fpk == apk.clone().into() {
         nickname = Some("Holo Fee Collector".to_string());
     }
-    if ReserveSetting::load_happ_file().is_ok() {
+    if ReserveSettingFile::load_happ_file().is_ok() {
         nickname = Some("HOT Reserve".to_string());
     }
     debug!("Setting nickname as {:?}", nickname);

--- a/crates/holofuel_init/src/main.rs
+++ b/crates/holofuel_init/src/main.rs
@@ -20,7 +20,6 @@ async fn main() -> Result<()> {
         // all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)
         // will be written to stdout.
         .with_max_level(Level::TRACE)
-        // completes the builder.
         .finish();
 
     tracing::subscriber::set_global_default(subscriber)?;
@@ -48,7 +47,7 @@ async fn main() -> Result<()> {
 
     let fpk = fee_collector_pubkey()?;
     let mut nickname = Some("Holo Account".to_string());
-    if fpk == apk.into() {
+    if fpk == apk.clone().into() {
         nickname = Some("Holo Fee Collector".to_string());
     }
     if ReserveSetting::load_happ_file().is_ok() {
@@ -72,7 +71,7 @@ async fn main() -> Result<()> {
     };
 
     // initialize reserve details
-    reserve_init::set_up_reserve(agent).await?;
+    reserve_init::set_up_reserve(agent, apk).await?;
     info!("Completed initializing the holofuel instance");
     Ok(())
 }

--- a/crates/holofuel_init/src/reserve_init.rs
+++ b/crates/holofuel_init/src/reserve_init.rs
@@ -1,17 +1,21 @@
 use anyhow::Result;
-use holochain_types::dna::HoloHash;
 use holochain_types::dna::hash_type::Agent;
+use holochain_types::dna::HoloHash;
 use holochain_types::prelude::{ExternIO, FunctionName, ZomeName};
 use hpos_hc_connect::holofuel_types::{Reserve, ReserveSalePrice, ReserveSetting};
 use hpos_hc_connect::HolofuelAgent;
-use tracing::{info, warn, trace, instrument};
+use tracing::{info, instrument, trace, warn};
 
 #[instrument(err, skip(agent))]
-pub async fn set_up_reserve(mut agent: HolofuelAgent, agent_pub_key: HoloHash<Agent>) -> Result<()> {
+pub async fn set_up_reserve(
+    mut agent: HolofuelAgent,
+    agent_pub_key: HoloHash<Agent>,
+) -> Result<()> {
     trace!("Setting up reserve settings...");
     match ReserveSetting::load_happ_file() {
         Ok(mut reserve_settings) => {
-            let agent_pub_key_byte_arr:[u8; 32] = <[u8; 32]>::try_from(agent_pub_key.get_raw_32())?;
+            let agent_pub_key_byte_arr: [u8; 32] =
+                <[u8; 32]>::try_from(agent_pub_key.get_raw_32())?;
             reserve_settings.external_signing_key = agent_pub_key_byte_arr.into();
             trace!("Getting all reserve account details");
             let result = agent

--- a/crates/holofuel_init/src/reserve_init.rs
+++ b/crates/holofuel_init/src/reserve_init.rs
@@ -1,14 +1,18 @@
 use anyhow::Result;
+use holochain_types::dna::HoloHash;
+use holochain_types::dna::hash_type::Agent;
 use holochain_types::prelude::{ExternIO, FunctionName, ZomeName};
 use hpos_hc_connect::holofuel_types::{Reserve, ReserveSalePrice, ReserveSetting};
 use hpos_hc_connect::HolofuelAgent;
 use tracing::{info, warn, trace, instrument};
 
 #[instrument(err, skip(agent))]
-pub async fn set_up_reserve(mut agent: HolofuelAgent) -> Result<()> {
+pub async fn set_up_reserve(mut agent: HolofuelAgent, agent_pub_key: HoloHash<Agent>) -> Result<()> {
     trace!("Setting up reserve settings...");
     match ReserveSetting::load_happ_file() {
-        Ok(reserve_settings) => {
+        Ok(mut reserve_settings) => {
+            let agent_pub_key_byte_arr:[u8; 32] = <[u8; 32]>::try_from(agent_pub_key.get_raw_32())?;
+            reserve_settings.external_signing_key = agent_pub_key_byte_arr.into();
             trace!("Getting all reserve account details");
             let result = agent
                 .zome_call(

--- a/crates/holofuel_init/src/reserve_init.rs
+++ b/crates/holofuel_init/src/reserve_init.rs
@@ -2,9 +2,9 @@ use anyhow::Result;
 use holochain_types::prelude::{ExternIO, FunctionName, ZomeName};
 use hpos_hc_connect::holofuel_types::{Reserve, ReserveSalePrice, ReserveSetting};
 use hpos_hc_connect::HolofuelAgent;
-use tracing::log::trace;
-use tracing::{info, log::warn};
+use tracing::{info, warn, trace, instrument};
 
+#[instrument(err, skip(agent))]
 pub async fn set_up_reserve(mut agent: HolofuelAgent) -> Result<()> {
     trace!("Setting up reserve settings...");
     match ReserveSetting::load_happ_file() {

--- a/crates/holofuel_init/src/reserve_init.rs
+++ b/crates/holofuel_init/src/reserve_init.rs
@@ -18,7 +18,7 @@ pub async fn set_up_reserve(mut agent: HolofuelAgent) -> Result<()> {
                 )
                 .await?;
             let reserve: Vec<Reserve> = rmp_serde::from_slice(result.as_bytes())?;
-            if reserve.len() == 0 {
+            if reserve.is_empty() {
                 trace!("Setting reserve details");
                 // Setting initial reserve account details
                 agent

--- a/crates/hpos_hc_connect/src/holofuel_types.rs
+++ b/crates/hpos_hc_connect/src/holofuel_types.rs
@@ -93,7 +93,17 @@ pub struct ReserveSetting {
     pub max_external_currency_tx_size: String,
     note: Option<String>,
 }
-impl ReserveSetting {
+
+#[derive(Serialize, Deserialize, Debug, SerializedBytes)]
+pub struct ReserveSettingFile {
+    pub external_reserve_currency: String,
+    pub external_account_number: String,
+    pub default_promise_expiry: Duration,
+    pub min_external_currency_tx_size: String,
+    pub max_external_currency_tx_size: String,
+    note: Option<String>,
+}
+impl ReserveSettingFile {
     pub fn load_happ_file() -> Result<Self> {
         debug!("loading happ file");
         let path = std::env::var("REGISTER_RESERVE")
@@ -107,6 +117,18 @@ impl ReserveSetting {
         debug!("happ file {:?}", happ_file);
         Ok(happ_file)
     }
+
+    pub fn into_reserve_settings(self, agent_pub_key: X25519PubKey) -> ReserveSetting {
+        ReserveSetting {
+            external_reserve_currency: self.external_reserve_currency,
+            external_account_number: self.external_account_number,
+            external_signing_key: agent_pub_key,
+            default_promise_expiry: self.default_promise_expiry,
+            min_external_currency_tx_size: self.min_external_currency_tx_size,
+            max_external_currency_tx_size: self.max_external_currency_tx_size,
+            note: self.note,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, SerializedBytes)]
@@ -117,12 +139,12 @@ pub struct ReserveSalePrice {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::holofuel_types::ReserveSetting;
+    use crate::holofuel_types::ReserveSettingFile;
 
     #[test]
     fn read_file() {
         use std::env::set_var;
         set_var("REGISTER_RESERVE", "./test/reserve_details.json");
-        ReserveSetting::load_happ_file().unwrap();
+        ReserveSettingFile::load_happ_file().unwrap();
     }
 }

--- a/crates/hpos_hc_connect/test/reserve_details.json
+++ b/crates/hpos_hc_connect/test/reserve_details.json
@@ -1,7 +1,6 @@
 {
   "external_reserve_currency": "HOT",
   "external_account_number": "tmp-account-number",
-  "external_signing_key": "00000000000000000000000000000000",
   "default_promise_expiry": { "secs": 2629743, "nanos": 0 },
   "min_external_currency_tx_size": "10",
   "max_external_currency_tx_size": "1000",


### PR DESCRIPTION
This PR:
- [x] changes the way that holofuel agent is registered on reserve. Agent PubKey is taken from a zomeCall, not from configuration file
- [x] enables logging in holofuel-init by activating tracing crate