### PR TITLE
Add Option<app_id> to holofuel-connect() method

### DIFF
--- a/crates/holofuel_cli/src/actions/actionable.rs
+++ b/crates/holofuel_cli/src/actions/actionable.rs
@@ -4,7 +4,7 @@ use hpos_hc_connect::holofuel_types::Actionable;
 use hpos_hc_connect::HolofuelAgent;
 
 pub async fn get() -> Result<()> {
-    let mut agent = HolofuelAgent::connect().await?;
+    let mut agent = HolofuelAgent::connect(None).await?;
     let result = agent
         .zome_call(
             ZomeName::from("transactor"),

--- a/crates/holofuel_cli/src/actions/completed.rs
+++ b/crates/holofuel_cli/src/actions/completed.rs
@@ -4,7 +4,7 @@ use hpos_hc_connect::holofuel_types::Transaction;
 use hpos_hc_connect::HolofuelAgent;
 
 pub async fn get() -> Result<()> {
-    let mut agent = HolofuelAgent::connect().await?;
+    let mut agent = HolofuelAgent::connect(None).await?;
     let result = agent
         .zome_call(
             ZomeName::from("transactor"),

--- a/crates/holofuel_cli/src/actions/ledger.rs
+++ b/crates/holofuel_cli/src/actions/ledger.rs
@@ -4,7 +4,7 @@ use hpos_hc_connect::holofuel_types::Ledger;
 use hpos_hc_connect::HolofuelAgent;
 
 pub async fn get() -> Result<()> {
-    let mut agent = HolofuelAgent::connect().await?;
+    let mut agent = HolofuelAgent::connect(None).await?;
     let result = agent
         .zome_call(
             ZomeName::from("transactor"),

--- a/crates/holofuel_cli/src/actions/pending.rs
+++ b/crates/holofuel_cli/src/actions/pending.rs
@@ -4,7 +4,7 @@ use hpos_hc_connect::holofuel_types::Pending;
 use hpos_hc_connect::HolofuelAgent;
 
 pub async fn get() -> Result<()> {
-    let mut agent = HolofuelAgent::connect().await?;
+    let mut agent = HolofuelAgent::connect(None).await?;
     let result = agent
         .zome_call(
             ZomeName::from("transactor"),

--- a/crates/holofuel_cli/src/actions/profile.rs
+++ b/crates/holofuel_cli/src/actions/profile.rs
@@ -4,7 +4,7 @@ use hpos_hc_connect::holofuel_types::Profile;
 use hpos_hc_connect::HolofuelAgent;
 
 pub async fn get() -> Result<()> {
-    let mut agent = HolofuelAgent::connect().await?;
+    let mut agent = HolofuelAgent::connect(None).await?;
     let result = agent
         .zome_call(
             ZomeName::from("profile"),

--- a/crates/holofuel_cli/src/actions/reserve.rs
+++ b/crates/holofuel_cli/src/actions/reserve.rs
@@ -4,7 +4,7 @@ use hpos_hc_connect::holofuel_types::{Reserve, ReserveSalePrice};
 use hpos_hc_connect::HolofuelAgent;
 
 pub async fn get_setting() -> Result<()> {
-    let mut agent = HolofuelAgent::connect().await?;
+    let mut agent = HolofuelAgent::connect(None).await?;
     let result = agent
         .zome_call(
             ZomeName::from("reserves"),
@@ -24,7 +24,7 @@ pub async fn get_setting() -> Result<()> {
 }
 
 pub async fn get_sale_price() -> Result<()> {
-    let mut agent = HolofuelAgent::connect().await?;
+    let mut agent = HolofuelAgent::connect(None).await?;
     let result = agent
         .zome_call(
             ZomeName::from("reserves"),

--- a/crates/holofuel_init/src/main.rs
+++ b/crates/holofuel_init/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
 
     info!("Start initializing the holofuel instance");
 
-    let mut agent = HolofuelAgent::connect().await?;
+    let mut agent = HolofuelAgent::connect(None).await?;
 
     #[derive(Serialize, Deserialize, Debug, SerializedBytes)]
     pub struct ProfileInput {

--- a/crates/hpos_hc_connect/src/hf_agent.rs
+++ b/crates/hpos_hc_connect/src/hf_agent.rs
@@ -39,7 +39,9 @@ impl HolofuelAgent {
             holofuel_id = id;
         } else {
             let app_file = HappsFile::build()?;
-            let holofuel = app_file.holofuel().ok_or(anyhow!("Could not find a holofuel in HPOS file"))?;
+            let holofuel = app_file
+                .holofuel()
+                .ok_or(anyhow!("Could not find a holofuel in HPOS file"))?;
             holofuel_id = holofuel.id();
         }
 
@@ -65,7 +67,10 @@ impl HolofuelAgent {
                 agent_pub_key,
                 ..
             }) => {
-                let cell = match &cell_info.get("holofuel").ok_or(anyhow!("there's no cell named holofuel!"))?[0] {
+                let cell = match &cell_info
+                    .get("holofuel")
+                    .ok_or(anyhow!("there's no cell named holofuel!"))?[0]
+                {
                     CellInfo::Provisioned(c) => c.clone(),
                     _ => return Err(anyhow!("unable to find holofuel")),
                 };


### PR DESCRIPTION
Currently whenever we create `HolofuelAgent` using `connect()` method there is no way to pass any identification of an instance of the holofuel we want to connect to.

This PR adds a functionality, where `connect()` takes holofuel's `app_id` as an optional parameter, and when `None` is passed crate will automatically reconstruct `app_id` from passed environmental variables on HPOS.

This work is required for integration tests in [reserve-controller-rust](https://github.com/Holo-Host/reserve-controller-rust/blob/test-things/src/sandbox.rs#L284) repo.